### PR TITLE
修复quartz执行时间相差1000倍的bugs

### DIFF
--- a/nutz-integration-quartz/src/main/java/org/nutz/integration/quartz/NutQuartzCronJobFactory.java
+++ b/nutz-integration-quartz/src/main/java/org/nutz/integration/quartz/NutQuartzCronJobFactory.java
@@ -67,7 +67,7 @@ public class NutQuartzCronJobFactory {
         else if (scheduled.fixedRate() > 0){
             log.debugf("job define name=%s fixedRate=%s count=%s initialDelay=%s", 
                     name, scheduled.fixedRate(), scheduled.count(), scheduled.initialDelay());
-            Quartzs.simple(scheduler, klass, scheduled.fixedRate(), scheduled.count(), scheduled.initialDelay(),null,null);
+            Quartzs.simple(scheduler, klass, scheduled.fixedRate(), scheduled.count(), scheduled.initialDelay());
         }
     }
     

--- a/nutz-integration-quartz/src/main/java/org/nutz/integration/quartz/Quartzs.java
+++ b/nutz-integration-quartz/src/main/java/org/nutz/integration/quartz/Quartzs.java
@@ -43,18 +43,22 @@ public class Quartzs {
         }
     }
     
-    public static void simple(Scheduler scheduler, Class<?> klass, int fixedRate, int count, long initialDelay,Date startTime,Date endTime) {
-        try {
-            String name = klass.getName();
-            String group = Scheduler.DEFAULT_GROUP;
-            JobKey jobKey = new JobKey(name, group);
-            if (scheduler.checkExists(jobKey))
-                scheduler.deleteJob(jobKey);
-            scheduler.scheduleJob(makeJob(jobKey, klass), makeSimpleTrigger(name, group, fixedRate, count, initialDelay, startTime, endTime));
-        }
-        catch (SchedulerException e) {
-            throw new RuntimeException(e);
-        }
+    public static void simple(Scheduler scheduler, Class<?> klass, int fixedRate, int count, long initialDelay) {
+        simple(scheduler, klass, fixedRate, count, initialDelay, null, null);
+    }
+    
+    public static void simple(Scheduler scheduler, Class<?> klass, int fixedRate, int count, long initialDelay, Date startTime, Date endTime) {
+    	try {
+    		String name = klass.getName();
+    		String group = Scheduler.DEFAULT_GROUP;
+    		JobKey jobKey = new JobKey(name, group);
+    		if (scheduler.checkExists(jobKey))
+    			scheduler.deleteJob(jobKey);
+    		scheduler.scheduleJob(makeJob(jobKey, klass), makeSimpleTrigger(name, group, fixedRate, count, initialDelay, startTime, endTime));
+    	}
+    	catch (SchedulerException e) {
+    		throw new RuntimeException(e);
+    	}
     }
     
     public static CronTrigger makeCronTrigger(String jobName, String jobGroup, String cron) {
@@ -63,27 +67,31 @@ public class Quartzs {
                 .build();
     }
     
-    public static SimpleTrigger makeSimpleTrigger(String jobName, String jobGroup, int fixedRate, int count, long initialDelay,Date startTime,Date endTime) {
-        SimpleScheduleBuilder schedule = SimpleScheduleBuilder.simpleSchedule();
-        if (fixedRate > 0)
-            schedule.withIntervalInSeconds(fixedRate / 1000);
-        if (count > 0) {
-            schedule.withRepeatCount(count);
-        } else {
-            schedule.repeatForever();
-        }
-        
-        TriggerBuilder<SimpleTrigger> trigger = TriggerBuilder.newTrigger().withIdentity(jobName, jobGroup).withSchedule(schedule);
-        if (startTime != null ) {
-        	trigger.startAt(startTime);
-		}
-        if (endTime != null ) {
-        	trigger.endAt(endTime);
-        }
-        
-        if (initialDelay > 0) 
-            trigger.startAt(new Date(System.currentTimeMillis() + initialDelay*1000));
-        return trigger.build();
+    public static SimpleTrigger makeSimpleTrigger(String jobName, String jobGroup, int fixedRate, int count, long initialDelay) {
+       return makeSimpleTrigger(jobName, jobGroup, fixedRate, count, initialDelay, null, null);
+    }
+    
+    public static SimpleTrigger makeSimpleTrigger(String jobName, String jobGroup, int fixedRate, int count, long initialDelay, Date startTime, Date endTime) {
+    	SimpleScheduleBuilder schedule = SimpleScheduleBuilder.simpleSchedule();
+    	if (fixedRate > 0)
+    		schedule.withIntervalInSeconds(fixedRate / 1000);
+    	if (count > 0) {
+    		schedule.withRepeatCount(count);
+    	} else {
+    		schedule.repeatForever();
+    	}
+    	
+    	TriggerBuilder<SimpleTrigger> trigger = TriggerBuilder.newTrigger().withIdentity(jobName, jobGroup).withSchedule(schedule);
+    	if (startTime != null ) {
+    		trigger.startAt(startTime);
+    	}
+    	if (endTime != null ) {
+    		trigger.endAt(endTime);
+    	}
+    	
+    	if (initialDelay > 0)
+    		trigger.startAt(new Date(System.currentTimeMillis() + initialDelay*1000));
+    	return trigger.build();
     }
     
     public static JobDetail makeJob(String jobName, String jobGroup, Class<?> klass) {


### PR DESCRIPTION
1. org.nutz.integration.quartz.Quartzs中的makeSimpleTrigger()方法中：

- 参数fixedRate为毫秒，这里set到schedule时当成了秒，导致执行时间相差1000倍

- 缺少两个参数Date startTime 和 Date endTime，trigger里面没有传入开始时间和结束时间，会导致默认当前时间为开始时间，结束时间为空。

2. org.nutz.integration.quartz.QuartzJob中的getTrigger()方法中，需要同步增加开始时间和结束时间两个参数

1. 这个问题只影响使用SimpleTrigger的quartz，不影响CronTrigger的quartz。

nutz中使用SimpleTrigger的quartz示例代码如下：

`		JobDetail jobDetail = newJob(SendInfoToWatch.class)
				.withIdentity("job1", "group1")
				.usingJobData("imei", String.valueOf(imei))
			      .usingJobData("info", info)
				.build();
`

`SimpleTrigger  trigger =  newTrigger()
				 .withIdentity("trigger1", "group1")
				 .startAt(start)
				 .forJob(jobDetail)
			     .withSchedule(SimpleScheduleBuilder.repeatHourlyForever(hours))
			     .endAt(end)
			     .build();
`

` JobKey jobKey = new JobKey("job1_trigger1","group1");
` 

` QuartzJob qj = new QuartzJob(jobKey, trigger, jobDetail);` 

` quartzManager.add(qj);`