### PR TITLE
修复了Pager对象自引用导致的序列化问题

### DIFF
--- a/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
+++ b/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
@@ -25,7 +25,7 @@ public class SqlManagerAutoConfiguration extends ApplicationObjectSupport {
 
   @Bean
   @ConditionalOnMissingBean
-  public SpringResourceLoaction initializeSpringResourceLocation() {
+  public SpringResourceLoaction springResourceLoaction() {
     SpringResourceLoaction springResourceLoaction = new SpringResourceLoaction();
     Scans.me().addResourceLocation(springResourceLoaction);
     return springResourceLoaction;

--- a/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
+++ b/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
@@ -1,12 +1,8 @@
 package org.nutz.plugin.spring.boot;
 
-import javax.annotation.PostConstruct;
-
 import org.nutz.dao.SqlManager;
 import org.nutz.dao.impl.FileSqlManager;
 import org.nutz.integration.spring.SpringResourceLoaction;
-import org.nutz.log.Log;
-import org.nutz.log.Logs;
 import org.nutz.plugin.spring.boot.config.SqlManagerProperties;
 import org.nutz.plugin.spring.boot.config.SqlManagerProperties.Mode;
 import org.nutz.plugins.sqlmanager.xml.XmlSqlManager;
@@ -24,32 +20,25 @@ import org.springframework.context.support.ApplicationObjectSupport;
 @EnableConfigurationProperties(SqlManagerProperties.class)
 public class SqlManagerAutoConfiguration extends ApplicationObjectSupport {
 
-    Log log = Logs.get();
+  @Autowired
+  private SqlManagerProperties sqlManagerProperties;
 
-    @Autowired
-    private SqlManagerProperties sqlManagerProperties;
+  @Bean
+  @ConditionalOnMissingBean
+  public SpringResourceLoaction initializeSpringResourceLocation() {
+    SpringResourceLoaction springResourceLoaction = new SpringResourceLoaction();
+    Scans.me().addResourceLocation(springResourceLoaction);
+    return springResourceLoaction;
+  }
 
-    @Autowired
-    private SpringResourceLoaction loaction;
-
-    @PostConstruct
-    public void init() {// 初始化一下nutz的扫描
-        Scans.me().addResourceLocation(loaction);
+  @Bean
+  @ConditionalOnMissingBean
+  public SqlManager sqlManager() {
+    String[] paths = sqlManagerProperties.getPaths();
+    if (paths == null) {
+      paths = new String[]{"sqls"};
     }
-
-    @Bean
-    public SpringResourceLoaction springResourceLoaction() {
-        return new SpringResourceLoaction();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SqlManager sqlManager() {
-        String[] paths = sqlManagerProperties.getPaths();
-        if (paths == null) {
-            paths = new String[]{"sqls"};
-        }
-        return sqlManagerProperties.getMode() == Mode.XML ? new XmlSqlManager(paths) : new FileSqlManager(paths);
-    }
+    return sqlManagerProperties.getMode() == Mode.XML ? new XmlSqlManager(paths) : new FileSqlManager(paths);
+  }
 
 }

--- a/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/service/entity/PageredData.java
+++ b/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/service/entity/PageredData.java
@@ -33,7 +33,9 @@ public class PageredData<T> extends Pager {
     }
 
     public Pager getPager() {
-        return this;
+        Pager pager = new Pager(getPageNumber(), getPageSize());
+        pager.setRecordCount(getRecordCount());
+        return pager;
     }
 
     @Deprecated


### PR DESCRIPTION
# PR说明

## 标题
修复了Pager对象自引用导致的序列化问题

## 描述
解决了一个关于`org.nutz.dao.pager.Pager`对象的序列化问题。原来的代码中，`getPager()`方法直接返回了当前对象，这在使用Jackson进行序列化时，会导致`com.fasterxml.jackson.databind.exc.InvalidDefinitionException`异常，因为Jackson会尝试序列化`Pager`对象时遇到自引用，进而导致无限循环。

错误堆栈如下：
```
Type definition error: [simple type, class org.nutz.dao.pager.Pager]; nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Direct self-reference leading to cycle (through reference chain: 
```

为了解决这个问题，修改了`getPager()`方法的实现，使其返回一个新的`Pager`对象，而不是当前对象。