### PR TITLE
fix: springResourceLoaction 上下文中依赖循环问题

### DIFF
--- a/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
+++ b/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
@@ -25,7 +25,7 @@ public class SqlManagerAutoConfiguration extends ApplicationObjectSupport {
 
   @Bean
   @ConditionalOnMissingBean
-  public SpringResourceLoaction initializeSpringResourceLocation() {
+  public SpringResourceLoaction springResourceLoaction() {
     SpringResourceLoaction springResourceLoaction = new SpringResourceLoaction();
     Scans.me().addResourceLocation(springResourceLoaction);
     return springResourceLoaction;

--- a/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
+++ b/nutz-plugins-spring-boot-starter/src/main/java/org/nutz/plugin/spring/boot/SqlManagerAutoConfiguration.java
@@ -1,12 +1,8 @@
 package org.nutz.plugin.spring.boot;
 
-import javax.annotation.PostConstruct;
-
 import org.nutz.dao.SqlManager;
 import org.nutz.dao.impl.FileSqlManager;
 import org.nutz.integration.spring.SpringResourceLoaction;
-import org.nutz.log.Log;
-import org.nutz.log.Logs;
 import org.nutz.plugin.spring.boot.config.SqlManagerProperties;
 import org.nutz.plugin.spring.boot.config.SqlManagerProperties.Mode;
 import org.nutz.plugins.sqlmanager.xml.XmlSqlManager;
@@ -24,32 +20,25 @@ import org.springframework.context.support.ApplicationObjectSupport;
 @EnableConfigurationProperties(SqlManagerProperties.class)
 public class SqlManagerAutoConfiguration extends ApplicationObjectSupport {
 
-    Log log = Logs.get();
+  @Autowired
+  private SqlManagerProperties sqlManagerProperties;
 
-    @Autowired
-    private SqlManagerProperties sqlManagerProperties;
+  @Bean
+  @ConditionalOnMissingBean
+  public SpringResourceLoaction initializeSpringResourceLocation() {
+    SpringResourceLoaction springResourceLoaction = new SpringResourceLoaction();
+    Scans.me().addResourceLocation(springResourceLoaction);
+    return springResourceLoaction;
+  }
 
-    @Autowired
-    private SpringResourceLoaction loaction;
-
-    @PostConstruct
-    public void init() {// 初始化一下nutz的扫描
-        Scans.me().addResourceLocation(loaction);
+  @Bean
+  @ConditionalOnMissingBean
+  public SqlManager sqlManager() {
+    String[] paths = sqlManagerProperties.getPaths();
+    if (paths == null) {
+      paths = new String[]{"sqls"};
     }
-
-    @Bean
-    public SpringResourceLoaction springResourceLoaction() {
-        return new SpringResourceLoaction();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SqlManager sqlManager() {
-        String[] paths = sqlManagerProperties.getPaths();
-        if (paths == null) {
-            paths = new String[]{"sqls"};
-        }
-        return sqlManagerProperties.getMode() == Mode.XML ? new XmlSqlManager(paths) : new FileSqlManager(paths);
-    }
+    return sqlManagerProperties.getMode() == Mode.XML ? new XmlSqlManager(paths) : new FileSqlManager(paths);
+  }
 
 }


### PR DESCRIPTION
解决了一个在Spring Boot应用中引发的Bean依赖循环问题。具体的错误信息如下：

```
The dependencies of some of the beans in the application context form a cycle:
....
      ↓
   dataPermissionService
      ↓
   dao defined in class path resource [org/nutz/plugin/spring/boot/NutzDaoAutoConfiguration.class]
┌─────┐
|  sqlManagerAutoConfiguration (field private org.nutz.integration.spring.SpringResourceLoaction org.nutz.plugin.spring.boot.SqlManagerAutoConfiguration.loaction)
└─────┘
```

问题源自于`SqlManagerAutoConfiguration`类中的`SpringResourceLoaction`实例的初始化。在原始代码中，在`@PostConstruct`注解的`init()`方法中添加了`SpringResourceLoaction`到Nutz的资源扫描器（Scans）中。这导致在Spring Boot的Bean初始化过程中出现了依赖循环。

修改后的代码如下：

```java
@Bean
@ConditionalOnMissingBean
public SpringResourceLoaction initializeSpringResourceLocation() {
  SpringResourceLoaction springResourceLoaction = new SpringResourceLoaction();
  Scans.me().addResourceLocation(springResourceLoaction);
  return springResourceLoaction;
}
```

## 测试环境：

修改已在以下环境中进行了测试：

- Spring Boot版本：2.7.18
- Java版本：8、11
